### PR TITLE
Profile picture crop control.

### DIFF
--- a/OpenEmail.Contracts/Application/IDialogService.cs
+++ b/OpenEmail.Contracts/Application/IDialogService.cs
@@ -6,9 +6,9 @@ namespace OpenEmail.Contracts.Application
     public interface IDialogService
     {
         Task ShowAddNewContactDialogAsync();
-        Task<byte[]> ShowProfilePicturePickerAsync();
         Task ShowMessageAsync(string title, string message, WindowType mainWindowType = WindowType.Shell);
         void ShowInfoBarMessage(string title, string message, InfoBarMessageSeverity severity, bool autoDismiss = true);
         Task<bool> ShowConfirmationDialogAsync(string title, string message, WindowType windowType = WindowType.Shell);
+        Task<byte[]> ShowProfilePictureEditorAsync();
     }
 }

--- a/OpenEmail.Contracts/Services/IProfileDataManager.cs
+++ b/OpenEmail.Contracts/Services/IProfileDataManager.cs
@@ -10,7 +10,6 @@ namespace OpenEmail.Contracts.Services
     /// </summary>
     public interface IProfileDataManager
     {
-        bool CanSaveImage(byte[] imageData);
         Task DeleteProfileImageAsync(UserAddress address);
 
         /// <summary>
@@ -18,6 +17,13 @@ namespace OpenEmail.Contracts.Services
         /// </summary>
         /// <param name="address">Address to get the profile data for.</param>
         Task<ProfileData> GetProfileDataAsync(UserAddress address, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Validates avatar size and dimensions. Resizes the image if necessary.
+        /// </summary>
+        /// <param name="pickedFileBytes"></param>
+        /// <returns>Image data in allowed limits.</returns>
+        byte[] GetValidAvatar(byte[] pickedFileBytes);
 
         /// <summary>
         /// Returns whether the profile data for the given address exists.

--- a/OpenEmail.Contracts/Services/IProfileDataService.cs
+++ b/OpenEmail.Contracts/Services/IProfileDataService.cs
@@ -33,8 +33,7 @@ namespace OpenEmail.Contracts.Services
         /// </summary>
         /// <param name="address">Address to update profile for.</param>
         /// <param name="imageData">Resized byte array of image data.</param>
-        /// <returns></returns>
-        Task<bool> UpdateProfileImageAsync(UserAddress address, byte[] imageData, CancellationToken cancellationToken = default);
+        Task UpdateProfileImageAsync(UserAddress address, byte[] imageData, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes user's avatar.

--- a/OpenEmail.Core/DataServices/ProfileDataService.cs
+++ b/OpenEmail.Core/DataServices/ProfileDataService.cs
@@ -78,22 +78,12 @@ namespace OpenEmail.Core.DataServices
             return await RefreshProfileDataAsync(address, refreshProfileImage: false, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<bool> UpdateProfileImageAsync(UserAddress address, byte[] imageData, CancellationToken cancellationToken = default)
+        public async Task UpdateProfileImageAsync(UserAddress address, byte[] imageData, CancellationToken cancellationToken = default)
         {
             var client = _clientFactory.CreateProfileClient<IProfileClient>();
             var updatedMessage = await client.UpdateProfileImageAsync(address, new ByteArrayContent(imageData), cancellationToken);
 
-            if (updatedMessage.IsSuccessStatusCode)
-            {
-                // Update locally if success.
-                await _profileDataManager.SaveProfileImageAsync(imageData, address, cancellationToken).ConfigureAwait(false);
-
-                WeakReferenceMessenger.Default.Send(new ProfileImageUpdated());
-            }
-            else
-                return false;
-
-            return true;
+            updatedMessage.EnsureSuccessStatusCode();
         }
     }
 }

--- a/OpenEmail/Controls/ProfilePictureEditControl.xaml
+++ b/OpenEmail/Controls/ProfilePictureEditControl.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="OpenEmail.Controls.ProfilePictureEditControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:OpenEmail.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    HorizontalContentAlignment="Stretch"
+    VerticalContentAlignment="Stretch"
+    Loaded="ControlLoaded"
+    mc:Ignorable="d">
+
+    <Grid RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <controls:ImageCropper
+            x:Name="cropper"
+            Width="400"
+            Height="400"
+            AspectRatio="1"
+            CropShape="Rectangular" />
+
+        <Grid Grid.Row="1" ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Button
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Click="SaveClicked"
+                Content="Save"
+                Style="{ThemeResource AccentButtonStyle}" />
+            <Button
+                Grid.Column="1"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Click="ResetClicked"
+                Content="Reset" />
+
+            <Button
+                Grid.Column="2"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Click="CancelClicked"
+                Content="Cancel" />
+        </Grid>
+    </Grid>
+</UserControl>
+

--- a/OpenEmail/Controls/ProfilePictureEditControl.xaml.cs
+++ b/OpenEmail/Controls/ProfilePictureEditControl.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Storage;
+
+namespace OpenEmail.Controls
+{
+    public sealed partial class ProfilePictureEditControl : UserControl
+    {
+        public event EventHandler DismissRequested;
+        public StorageFile ImageFile { get; }
+        public byte[] ResultBytes { get; private set; }
+
+        public ProfilePictureEditControl(StorageFile imageFile)
+        {
+            InitializeComponent();
+            ImageFile = imageFile;
+        }
+
+        private async void ControlLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            if (ImageFile == null) return;
+
+            await cropper.LoadImageFromFile(ImageFile);
+        }
+
+        private void ResetClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e) => cropper.Reset();
+
+        private async void SaveClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var result = new MemoryStream();
+
+            var randomAccessStream = result.AsRandomAccessStream();
+            await cropper.SaveAsync(randomAccessStream, CommunityToolkit.WinUI.Controls.BitmapFileFormat.Jpeg, false);
+
+            result.Position = 0;
+            ResultBytes = result.ToArray();
+
+            Dismiss();
+        }
+
+        private void Dismiss() => DismissRequested?.Invoke(this, null);
+
+        private void CancelClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            Dismiss();
+        }
+    }
+}

--- a/OpenEmail/OpenEmail.csproj
+++ b/OpenEmail/OpenEmail.csproj
@@ -29,6 +29,7 @@
     <None Remove="Assets\titlebar_logo.png" />
     <None Remove="Controls\ContactProfileControl.xaml" />
     <None Remove="Controls\CustomAppBarButton.xaml" />
+    <None Remove="Controls\ProfilePictureEditControl.xaml" />
     <None Remove="Dialogs\AddNewContactDialog.xaml" />
     <None Remove="Styles\ButtonStyles.xaml" />
     <None Remove="Styles\Colors.xaml" />
@@ -54,6 +55,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.ImageCropper" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.1.240821" />
@@ -91,6 +93,11 @@
     <ProjectReference Include="..\OpenEmail.Core\OpenEmail.Core.csproj" />
     <ProjectReference Include="..\OpenEmail.ViewModels\OpenEmail.ViewModels.csproj" />
     <ProjectReference Include="..\OpenEmail.WinRT\OpenEmail.WinRT.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Controls\ProfilePictureEditControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Controls\CustomAppBarButton.xaml">

--- a/OpenEmail/Views/ProfileEditPage.xaml
+++ b/OpenEmail/Views/ProfileEditPage.xaml
@@ -104,18 +104,23 @@
             </Grid.ColumnDefinitions>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="400" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="2" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
             <!--  avatar  -->
             <Grid>
-                <Grid CornerRadius="6">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid Height="400" CornerRadius="6">
                     <Image Source="{x:Bind ViewModel.ContactProfilePicture, Mode=OneWay, Converter={StaticResource ProfileImageConverter}}" />
                 </Grid>
 
                 <StackPanel
+                    Grid.Row="1"
                     Margin="6"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"

--- a/OpenEmail/Views/ShellPage.xaml
+++ b/OpenEmail/Views/ShellPage.xaml
@@ -20,6 +20,7 @@
     xmlns:ui="using:CommunityToolkit.WinUI"
     IsDisplayingProfileControl="{x:Bind ViewModel.IsProfileLoadMenuVisible, Mode=OneWay}"
     KeyboardAcceleratorPlacementMode="Hidden"
+    RequestedTheme="Dark"
     mc:Ignorable="d">
 
     <Page.KeyboardAccelerators>


### PR DESCRIPTION
This PR implements cropping tool for changing avatars in profile edit page.

- Cropper's clip is a rectangle. It guarantees that the selected picture will always be a square.
- Files bigger than allowed dimensions (changed as 800x800) will be resized to 400x400.
- After the adjustments, if the image file still exceeds the allowed size limit (changed to 640 kb) user will be notified to select smaller picture and crop it.
- Fixed an issue where avatar as not updated in the profile edit page.
- Fixed an issue when error was thrown but not shown to user.
